### PR TITLE
remove symfony 3 legacy event handling code

### DIFF
--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -25,8 +25,6 @@ use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCache\ProxyClient\Symfony;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
-use Symfony\Component\HttpKernel\Kernel;
 use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 /**
@@ -143,11 +141,7 @@ class CacheInvalidator
     public function getEventDispatcher()
     {
         if (!$this->eventDispatcher) {
-            if (class_exists(LegacyEventDispatcherProxy::class)) {
-                $this->eventDispatcher = LegacyEventDispatcherProxy::decorate(new EventDispatcher());
-            } else {
-                $this->eventDispatcher = new EventDispatcher();
-            }
+            $this->eventDispatcher = new EventDispatcher();
         }
 
         return $this->eventDispatcher;
@@ -310,18 +304,13 @@ class CacheInvalidator
                 $event = new Event();
                 $event->setException($exception);
                 if ($exception instanceof ProxyResponseException) {
-                    $this->dispatch($event, Events::PROXY_RESPONSE_ERROR);
+                    $this->getEventDispatcher()->dispatch($event, Events::PROXY_RESPONSE_ERROR);
                 } elseif ($exception instanceof ProxyUnreachableException) {
-                    $this->dispatch($event, Events::PROXY_UNREACHABLE_ERROR);
+                    $this->getEventDispatcher()->dispatch($event, Events::PROXY_UNREACHABLE_ERROR);
                 }
             }
 
             throw $exceptions;
         }
-    }
-
-    private function dispatch(Event $event, $eventName)
-    {
-        $this->getEventDispatcher()->dispatch($event, $eventName);
     }
 }

--- a/src/SymfonyCache/EventDispatchingHttpCache.php
+++ b/src/SymfonyCache/EventDispatchingHttpCache.php
@@ -14,11 +14,9 @@ namespace FOS\HttpCache\SymfonyCache;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Trait for enhanced Symfony reverse proxy based on the symfony kernel component.
@@ -57,11 +55,7 @@ trait EventDispatchingHttpCache
     public function getEventDispatcher()
     {
         if (!$this->eventDispatcher) {
-            if (class_exists(LegacyEventDispatcherProxy::class)) {
-                $this->eventDispatcher = LegacyEventDispatcherProxy::decorate(new EventDispatcher());
-            } else {
-                $this->eventDispatcher = new EventDispatcher();
-            }
+            $this->eventDispatcher = new EventDispatcher();
         }
 
         return $this->eventDispatcher;
@@ -133,7 +127,7 @@ trait EventDispatchingHttpCache
     }
 
     /**
-     * Dispatch an event if needed.
+     * Dispatch an event if there are any listeners.
      *
      * @param string        $name        Name of the event to trigger. One of the constants in FOS\HttpCache\SymfonyCache\Events
      * @param Response|null $response    If already available


### PR DESCRIPTION
i found that there are more things we should remove

adding a commit to https://github.com/FriendsOfSymfony/FOSHttpCache/pull/520